### PR TITLE
Fix StrictConcurrency usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 			dependencies: [
 			],
 			swiftSettings: [
-				.enableUpcomingFeature("StrictConcurrency"),
+				.enableExperimentalFeature("StrictConcurrency"),
 			]
 		),
 		.testTarget(

--- a/Sources/Glob/Pattern+Options.swift
+++ b/Sources/Glob/Pattern+Options.swift
@@ -2,9 +2,9 @@ import Foundation
 
 public extension Pattern {
 	/// Options to control how patterns are parsed and matched
-	struct Options {
+	struct Options: Sendable {
 		/// How wildcards are interpreted
-		public enum WildcardBehavior {
+		public enum WildcardBehavior: Sendable {
 			/// A single star/asterisk will match any character, including the path separator
 			///
 			/// Additional star/asterisks are ignored. This matches the behavior of fnmatch when `FNM_PATHNAME` is not provided.

--- a/Sources/Glob/Pattern.swift
+++ b/Sources/Glob/Pattern.swift
@@ -5,8 +5,8 @@ extension Character {
 }
 
 /// A glob pattern that can be matched against string content.
-public struct Pattern {
-	public enum Section: Equatable {
+public struct Pattern: Sendable {
+	public enum Section: Equatable, Sendable {
 		/// A wildcard that matches any 0 or more characters except for the path separator ("/" by default)
 		case componentWildcard
 		/// A wildcard that matches any 0 or more characters


### PR DESCRIPTION
Super easy mistake to make.

Please look at this one closely though, because while adding Sendable here was very easy, having to remove it later would be a problem.