### PR TITLE
Fix Glob.search returning paths with resolved symlinks

### DIFF
--- a/Sources/Glob/GlobSearch.swift
+++ b/Sources/Glob/GlobSearch.swift
@@ -79,10 +79,10 @@ public func search(
 						var options: FileManager.DirectoryEnumerationOptions = []
 						if skipHiddenFiles {
 							options.insert(.skipsHiddenFiles)
-                            #if !os(Linux)
-                            options.insert(.producesRelativePathURLs)
-                            #endif
 						}
+                        #if !os(Linux)
+                        options.insert(.producesRelativePathURLs)
+                        #endif
 						let contents = try FileManager.default.contentsOfDirectory(
 							at: directory,
 							includingPropertiesForKeys: keys + [.isDirectoryKey],


### PR DESCRIPTION
Hey @davbeck 👋 

We started to use `swift-glob` at [tuist](https://github.com/tuist/tuist) and when migrating from our [previous implementation](https://github.com/tuist/tuist/blob/main/Sources/TuistSupport/Utils/Glob.swift), I noticed that `Glob.search` returns resolved symlinks.

For example, we often run our tests in a temporary directory at `/var/...`. However, `/var` is actually a symbolic link to `/private/var`. If I run `Glob.search(directory: "/var/...", include: [try Pattern("some-glob/*.swift")])`, I'd expect to get  files that begin with `/var`. But that's not the case.

The reason the symlinks get resolved is because of `FileManager.default.contentsOfDirectory` that actually resolves those symlinks during the process. The solution is to base the path on the initial URL and then append a relative path for the contents to preserve the symlink.

I couldn't find any tests for `Glob.search` but I tested the behavior at https://github.com/tuist/FileSystem. Let me know if you want me to add tests here.